### PR TITLE
[SHIPA-2077] Flatten resources

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -11,55 +11,49 @@ provider "ketch" {}
 
 # Create framework
 resource "ketch_framework" "tf" {
-  framework {
-    name = "tf-dev"
-    ingress_controller {
-      class_name = "istio"
-      service_endpoint = "1.2.3.4"
-      type = "istio"
-    }
+  name = "tf-dev"
+  ingress_controller {
+    class_name = "istio"
+    service_endpoint = "1.2.3.4"
+    type = "istio"
   }
 }
 
 # Create app
 resource "ketch_app" "tf" {
-  app {
-    name = "tf-app1"
-    image = "docker.io/shipasoftware/bulletinboard:1.0"
-    framework = ketch_framework.tf.framework[0].name
-    cnames = [
-      "app1.ketch.io",
-      "app2.ketch.io",
-      "app3.ketch.io"]
-    ports = [8081, 8082]
-    units = 5
-    processes {
-      name = "web"
-      cmd = [
-        "docker-entrypoint.sh",
-        "npm",
-        "start"]
-    }
-    routing_settings {
-      weight = 100
-    }
+  name = "tf-app1"
+  image = "docker.io/shipasoftware/bulletinboard:1.0"
+  framework = ketch_framework.tf.name
+  cnames = [
+    "app1.ketch.io",
+    "app2.ketch.io",
+    "app3.ketch.io"]
+  ports = [8081, 8082]
+  units = 5
+  processes {
+    name = "web"
+    cmd = [
+      "docker-entrypoint.sh",
+      "npm",
+      "start"]
+  }
+  routing_settings {
+    weight = 100
   }
 }
 
 # Create job
 resource "ketch_job" "tf" {
-  job {
-    name = "tf-job1"
-    framework = "tf-dev"
-    containers {
-      name = "pi"
-      image = "perl"
-      command = [
-        "perl",
-        "-Mbignum=bpi",
-        "-wle",
-        "print bpi(2000)"
-      ]
-    }
+  name = "tf-job1"
+  framework = ketch_framework.tf.name
+  containers {
+    name = "pi"
+    image = "perl"
+    command = [
+      "perl",
+      "-Mbignum=bpi",
+      "-wle",
+      "print bpi(2000)"
+    ]
   }
 }

--- a/helper/converter.go
+++ b/helper/converter.go
@@ -57,7 +57,6 @@ func TerraformToStruct(source interface{}, target interface{}) {
 				continue
 			}
 
-
 			targetValue := tVal.Field(i)
 			//log.Printf("val: %+v, type: %t\n", val, val)
 			targetValue.Set(convertVal(sourceValue, targetValue))
@@ -133,15 +132,15 @@ func convertVal(from, to reflect.Value) reflect.Value {
 				// case when we have basic types
 				case reflect.String, reflect.Bool, reflect.Int, reflect.Int64, reflect.Float64:
 					item = from.MapIndex(key).Elem()
-				//default:
-				//	// case when we have pointer elements
-				//	if to.Type().Elem().Kind() == reflect.Ptr {
-				//		item = reflect.New(to.Type().Elem().Elem())
-				//	} else {
-				//		item = reflect.New(to.Type().Elem())
-				//	}
-				//
-				//	item = convertVal(from.Index(i), item)
+					//default:
+					//	// case when we have pointer elements
+					//	if to.Type().Elem().Kind() == reflect.Ptr {
+					//		item = reflect.New(to.Type().Elem().Elem())
+					//	} else {
+					//		item = reflect.New(to.Type().Elem())
+					//	}
+					//
+					//	item = convertVal(from.Index(i), item)
 				}
 
 				// if target slice is not slice of pointers
@@ -155,8 +154,6 @@ func convertVal(from, to reflect.Value) reflect.Value {
 			return m
 		}
 	}
-
-
 
 	if to.Kind() == reflect.Ptr {
 		if to.IsNil() {

--- a/ketch/resource_app_test.go
+++ b/ketch/resource_app_test.go
@@ -1,0 +1,69 @@
+package ketch
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/brunoa19/ketch-terraform-provider/client"
+)
+
+func TestExtractApp(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, schemaApp, map[string]interface{}{
+		"name":      "testjob",
+		"image":     "gcr.io/test",
+		"framework": "testfw",
+		"cnames":    []interface{}{"cname1", "cname2"},
+		"ports":     []interface{}{8080, 8081},
+		"units":     4,
+		"processes": []interface{}{
+			map[string]interface{}{
+				"cmd":  []interface{}{"./web"},
+				"name": "web",
+			},
+			map[string]interface{}{
+				"cmd":  []interface{}{"./worker", "-v"},
+				"name": "worker",
+			},
+		},
+		"routing_settings": []interface{}{
+			map[string]interface{}{"weight": 100},
+		},
+		"version":       2,
+		"backoff_limit": 5,
+		"policy": []interface{}{
+			map[string]interface{}{
+				"restart_policy": "NEVER",
+			}},
+		"containers": []interface{}{
+			map[string]interface{}{
+				"name":    "testcontainer",
+				"image":   "gcr.io/test",
+				"command": []interface{}{"ls", "-a"},
+			},
+		},
+	})
+	expected := &client.App{
+		Name:      "testjob",
+		Image:     "gcr.io/test",
+		Framework: "testfw",
+		Cname:     []string{"cname1", "cname2"},
+		Ports:     []int{8080, 8081},
+		Units:     4,
+		Processes: []*client.ProcessParameters{
+			{
+				Cmd:  []string{"./web"},
+				Name: "web",
+			},
+			{
+				Cmd:  []string{"./worker", "-v"},
+				Name: "worker",
+			},
+		},
+		RoutingSettings: &client.RoutingSettings{Weight: 100},
+		Version:         2,
+	}
+	app := extractApp(d)
+	require.Equal(t, expected, app)
+}

--- a/ketch/resource_framework_test.go
+++ b/ketch/resource_framework_test.go
@@ -1,0 +1,39 @@
+package ketch
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/brunoa19/ketch-terraform-provider/client"
+)
+
+func TestExtractFramework(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceFramework().Schema, map[string]interface{}{
+		"name":            "testfw",
+		"namespace":       "testns",
+		"app_quota_limit": 2,
+		"ingress_controller": []interface{}{
+			map[string]interface{}{
+				"class_name":       "traefik",
+				"service_endpoint": "10.10.10.10",
+				"type":             "traefik",
+				"cluster_issuer":   "test_issuer",
+			}},
+	})
+	expected := &client.Framework{
+		Name:          "testfw",
+		Namespace:     "testns",
+		AppQuotaLimit: 2,
+		IngressController: &client.IngressControllerSpec{
+			ClassName:       "traefik",
+			ServiceEndpoint: "10.10.10.10",
+			IngressType:     "traefik",
+			ClusterIssuer:   "test_issuer",
+		},
+	}
+
+	framework := extractFramework(d)
+	require.Equal(t, expected, framework)
+}

--- a/ketch/resource_job.go
+++ b/ketch/resource_job.go
@@ -2,11 +2,13 @@ package ketch
 
 import (
 	"context"
-	"github.com/brunoa19/ketch-terraform-provider/client"
-	"github.com/brunoa19/ketch-terraform-provider/helper"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"log"
+
+	"github.com/brunoa19/ketch-terraform-provider/client"
+	"github.com/brunoa19/ketch-terraform-provider/helper"
 )
 
 var (
@@ -56,54 +58,45 @@ func resourceJob() *schema.Resource {
 		UpdateContext: resourceJobUpdate,
 		DeleteContext: resourceJobDelete,
 		Schema: map[string]*schema.Schema{
-			"job": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
+			"name": {
+				Type:     schema.TypeString,
 				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						"type": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"framework": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"version": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"description": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"parallelism": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"completions": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"suspend": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"backoff_limit": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"containers": schemaJobContainers,
-						"policy":     schemaJobPolicy,
-					},
-				},
+				ForceNew: true,
 			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"framework": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"parallelism": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"completions": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"suspend": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"backoff_limit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"containers": schemaJobContainers,
+			"policy":     schemaJobPolicy,
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -111,17 +104,19 @@ func resourceJob() *schema.Resource {
 	}
 }
 
+func extractJob(d *schema.ResourceData) *client.Job {
+	raw := d.Get("")
+	var job client.Job
+	helper.TerraformToStruct(raw, &job)
+	return &job
+}
+
 func resourceJobCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 
-	raw := d.Get("job").([]interface{})[0].(map[string]interface{})
-
-	job := &client.Job{}
-	helper.TerraformToStruct(raw, job)
-
-	log.Printf("RAW job: %+v\n", raw)
-	log.Printf("CONVERTED job: %+v\n", *job)
+	job := extractJob(d)
+	log.Printf("CONVERTED job: %+v\n", job)
 
 	c := m.(*client.Client)
 	err := c.CreateJob(ctx, job)
@@ -148,24 +143,59 @@ func resourceJobRead(ctx context.Context, d *schema.ResourceData, m interface{})
 		return diag.FromErr(err)
 	}
 
-	if err = d.Set("job", helper.StructToTerraform(job)); err != nil {
+	err = d.Set("name", job.Name)
+	if err != nil {
 		return diag.FromErr(err)
 	}
-
+	err = d.Set("type", job.Type)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("framework", job.Framework)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("version", job.Version)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("description", job.Description)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("parallelism", job.Parallelism) // TODO
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("completions", job.Completions)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("suspend", job.Suspend)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("backoff_limit", job.BackoffLimit)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("containers", helper.StructToTerraform(&job.Containers))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("policy", helper.StructToTerraform(job.Policy))
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return diags
 }
 
 func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	if !d.HasChange("job") {
+	if !d.HasChange("") {
 		return resourceJobRead(ctx, d, m)
 	}
 
-	raw := d.Get("job").([]interface{})[0].(map[string]interface{})
-
-	job := &client.Job{}
-	helper.TerraformToStruct(raw, job)
-
-	log.Printf("RAW job: %+v\n", raw)
+	job := extractJob(d)
 
 	c := m.(*client.Client)
 	err := c.UpdateJob(ctx, job)

--- a/ketch/resource_job_test.go
+++ b/ketch/resource_job_test.go
@@ -1,0 +1,58 @@
+package ketch
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/brunoa19/ketch-terraform-provider/client"
+)
+
+func TestExtractJob(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceJob().Schema, map[string]interface{}{
+		"name":          "testjob",
+		"type":          "test",
+		"framework":     "testfw",
+		"version":       "v1",
+		"description":   "a test",
+		"parallelism":   3,
+		"completions":   2,
+		"suspend":       false,
+		"backoff_limit": 5,
+		"policy": []interface{}{
+			map[string]interface{}{
+				"restart_policy": "NEVER",
+			}},
+		"containers": []interface{}{
+			map[string]interface{}{
+				"name":    "testcontainer",
+				"image":   "gcr.io/test",
+				"command": []interface{}{"ls", "-a"},
+			},
+		},
+	})
+	expected := &client.Job{
+		Name:         "testjob",
+		Type:         "test",
+		Framework:    "testfw",
+		Version:      "v1",
+		Description:  "a test",
+		Parallelism:  3,
+		Completions:  2,
+		Suspend:      false,
+		BackoffLimit: 5,
+		Containers: []*client.Container{
+			{
+				Name:    "testcontainer",
+				Image:   "gcr.io/test",
+				Command: []string{"ls", "-a"},
+			},
+		},
+		Policy: &client.Policy{
+			RestartPolicy: "NEVER",
+		},
+	}
+	job := extractJob(d)
+	require.Equal(t, expected, job)
+}


### PR DESCRIPTION
I think we'd want the resources (`app`, `job`, and `framework`) to be base level objects and not slices within the terraform resource blocks. For example:

Currently:
```
resource "ketch_job" "tf" {
  job {
    name = "tf-job1"
    framework = ketch_framework.test.framework[0].name
    containers {
      name = "pi"
      image = "perl"
      command = [
        "perl",
        "-Mbignum=bpi",
        "-wle",
        "print bpi(2000)"
      ]
  }
}
```
Becomes:
```
resource "ketch_job" "tf" {
  name = "tf-job1"
  framework = ketch_framework.test.framework[0].name
  containers {
    name = "pi"
    image = "perl"
    command = [
      "perl",
      "-Mbignum=bpi",
      "-wle",
      "print bpi(2000)"
    ]
}
```

Then, we can reference framework within resources like `ketch_framework.test.framework.name` without the [0] index.

Adds unit tests to affirm the terraform->clientObject marshaling. 